### PR TITLE
feat: aggregate metrics by scenario name

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,34 @@ browser.page.LCP.https://artillery.io/pro/:
   p99: ...................................................... 206.5
 ```
 
+### Aggregate metrics by scenario name
+
+By default metrics are aggregated separately for each unique URL. When load testing the same endpoint with different/randomized query params, it can be hepful to group metrics by a common name. 
+
+To enable the option pass `aggregateByName: true` to the playwright engine and give a name to your scenarios:
+```
+config:
+  target: https://artillery.io
+  engines:
+    playwright: { aggregateByName: true } 
+  processor: "./flows.js"
+scenarios:
+  - name: blog
+    engine: playwright
+    flowFunction: "helloFlow"
+    flow: []
+```
+`flows.js`
+```
+module.exports = { helloFlow };
+
+function helloFlow(page) {
+  await page.goto(`https://artillery.io/blog/${getRandomSlug()}`);
+}
+```
+
+This serves a similar purpose to the `useOnlyRequestNames` option from the [metrics-by-endpoint](https://github.com/artilleryio/artillery-plugin-metrics-by-endpoint) artillery plugin.
+
 ## Flow function API
 
 By default, only the `page` argument (see Playwright's [`page` API](https://playwright.dev/docs/api/class-page/)) is required for functions that implement Playwright scenarios, e.g.:
@@ -195,6 +223,8 @@ function helloFlow(page, vuContext, events) {
   await page.goto('https://artillery.io/');
 }
 ```
+
+
 
 ## More examples
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,12 @@ class PlaywrightEngine {
     debug(spec);
 
     const self = this;
+
+    function getName(url) {
+      const { aggregateByName } = self.config.engines.playwright;
+      return aggregateByName && spec.name ? spec.name : url;
+    }
+    
     return async function scenario(initialContext, cb) {
       events.emit('started');
       const browser = await chromium.launch({
@@ -21,7 +27,7 @@ class PlaywrightEngine {
         args: [
           '--enable-precise-memory-info',
         ],
-        });
+      });
       debug('browser created');
       const context = await browser.newContext();
       debug('context created');
@@ -47,20 +53,19 @@ class PlaywrightEngine {
           const performanceTimingJson = await page.evaluate(() => JSON.stringify(window.performance.timing));
           const performanceTiming = JSON.parse(performanceTimingJson);
 
-          if(uniquePageLoadToTiming[page.url()+performanceTiming.connectStart]) {
+          if(uniquePageLoadToTiming[getName(page.url()) + performanceTiming.connectStart]) {
             return;
           } else {
-            uniquePageLoadToTiming[page.url()+performanceTiming.connectStart] = performanceTiming;
+            uniquePageLoadToTiming[getName(page.url()) + performanceTiming.connectStart] = performanceTiming;
           }
 
-          debug('domcontentloaded:', page.url());
-;
+          debug('domcontentloaded:', getName(page.url()));
           const startToInteractive = performanceTiming.domInteractive - performanceTiming.navigationStart;
 
           events.emit('counter', 'engine.browser.page.domcontentloaded', 1);
-          events.emit('counter', `engine.browser.page.domcontentloaded.${page.url()}`, 1);
+          events.emit('counter', `engine.browser.page.domcontentloaded.${getName(page.url())}`, 1);
           events.emit('histogram', 'engine.browser.page.dominteractive', startToInteractive);
-          events.emit('histogram', `engine.browser.page.dominteractive.${page.url()}`, startToInteractive);
+          events.emit('histogram', `engine.browser.page.dominteractive.${getName(page.url())}`, startToInteractive);
         });
 
         page.on('console', async msg => {
@@ -71,20 +76,20 @@ class PlaywrightEngine {
               // TODO: expose via extended metrics: TTFB
               if (metric.name === 'FCP' || metric.name === 'LCP') {
                 const { name, value, url } = metric;
-                events.emit('histogram', `engine.browser.page.${name}.${url}`, value);
+                events.emit('histogram', `engine.browser.page.${name}.${getName(url)}`, value);
               }
             } catch (err) {}
           }
         });
 
         page.on('load', async (page) => {
-          debug('load:', page.url());
+          debug('load:', getName(page.url()));
 
           const { usedJSHeapSize } = JSON.parse(await page.evaluate(() => JSON.stringify({usedJSHeapSize: window.performance.memory.usedJSHeapSize})));
           events.emit('histogram', 'engine.browser.memory_used_mb', usedJSHeapSize / 1000 / 1000);
         });
         page.on('pageerror', (error) => {
-          debug('pageerror:', page.url());
+          debug('pageerror:', getName(page.url()));
         });
         page.on('requestfinished', (request) => {
           // const timing = request.timing();


### PR DESCRIPTION
Currently the metrics are separately aggregated for each unique URL, which makes it a challenge when load testing the same endpoint with different/randomized query params. This PR adds the option to aggregate metrics by scenario name instead of url. 

It serves a similar purpose to the `useOnlyRequestNames` option from the [metrics-by-endpoint](https://github.com/artilleryio/artillery-plugin-metrics-by-endpoint) artillery plugin (which does not work with the playwright engine). 

To enable the option pass `aggregateByName: true` to the playwright engine and give a name to your scenarios:
```
config:
  target: https://artillery.io
  engines:
    playwright: { aggregateByName: true } 
  processor: "./flows.js"
scenarios:
  - name: blog
    engine: playwright
    flowFunction: "helloFlow"
    flow: []
```
`flows.js`
```
module.exports = { helloFlow };

function helloFlow(page) {
  await page.goto(`https://artillery.io/blog/${getRandomSlug()}`);
}
```

If this is an acceptable approach to solving the problem I'll add a commit to update the readme with the usage. @hassy looking forward to hearing your thoughts.
