### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artillery-engine-playwright",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -10,10 +10,10 @@
   "author": "",
   "license": "MPL-2.0",
   "dependencies": {
-    "debug": "^4.3.2",
-    "playwright": "^1.27.1"
+    "debug": "^4.3.4",
+    "playwright": "^1.29.2"
   },
   "devDependencies": {
-    "@playwright/test": "1.27.1"
+    "@playwright/test": "1.29.2"
   }
 }


### PR DESCRIPTION
If you look, npmjs has dependencies that are different than the committed Github ones with the same name.
To fix this, one needs to republish.  But while doing so, it'd be swell to upgrade PlayWright to the almost latest version 1.29.2 (over the last intended change 1.27.1)